### PR TITLE
devcontainer: set up Fast RTPS profile

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,6 +17,9 @@
 		"--ulimit",
 		"nofile=1024"
 	],
+	"containerEnv": {
+		"FASTRTPS_DEFAULT_PROFILES_FILE": "/home/cube/cube-its/fastrtps.xml"
+	},
 	// Mount bash history
 	"mounts": [
 		"source=projectname-bashhistory,target=/commandhistory,type=volume"

--- a/fastrtps.xml
+++ b/fastrtps.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<profiles xmlns="http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles" >
+    <transport_descriptors>
+        <transport_descriptor>
+            <transport_id>cube_udp</transport_id>
+            <type>UDPv4</type>
+        </transport_descriptor>
+    </transport_descriptors>
+
+    <participant profile_name="cube_profile" is_default_profile="true">
+        <rtps>
+            <userTransports>
+                <transport_id>cube_udp</transport_id>
+            </userTransports>
+            <!-- no output by "ros2 topic echo" for topics published on localhost:
+                 disabling built-in transports does the trick -->
+            <useBuiltinTransports>false</useBuiltinTransports>
+        </rtps>
+    </participant>
+</profiles>


### PR DESCRIPTION
Topics published by another container running on localhost with `--network=host --ipc=host` could be enlisted with `ros2 topic list` but no data could be received via `ros2 topic echo`.
This PR adds a FastRTPS profile that disables the built-in transports; everything works as expected then.