### PR TITLE
cpm_provider: fix Perceived Object Container creation

### DIFF
--- a/dev_ws/src/v2x_apps/v2x_apps/cpm_provider.py
+++ b/dev_ws/src/v2x_apps/v2x_apps/cpm_provider.py
@@ -118,10 +118,10 @@ class CpmProvider(Node):
 
         # Container
         container = cpm_msg.WrappedCpmContainer()
-        container.container_id.value = cpm_msg.CpmContainerId.PERCEIVED_OBJECT_CONTAINER
-        container.container_data.choice.value = cpm_msg.CpmContainerId.PERCEIVED_OBJECT_CONTAINER
-        container.container_data.perceived_object_container.number_of_perceived_objects.value = 1
-        container.container_data.perceived_object_container.perceived_objects.array = [
+        container.container_id.value = cpm_msg.WrappedCpmContainer.CHOICE_CONTAINER_DATA_PERCEIVED_OBJECT_CONTAINER
+        container.container_data_perceived_object_container = cpm_msg.PerceivedObjectContainer()
+        container.container_data_perceived_object_container.number_of_perceived_objects.value = 1
+        container.container_data_perceived_object_container.perceived_objects.array = [
             perceived_object]
 
         cpm = cpm_msg.CollectivePerceptionMessage()


### PR DESCRIPTION
Fixes to the formation of the Perceived Object Container from the **cpm_provider** using the [WrappedCpmContainer](https://github.com/cubesys-GmbH/etsi_its_messages/blob/main/etsi_its_msgs/etsi_its_cpm_ts_msgs/msg/WrappedCpmContainer.msg) attributes:

- Assigns the constant `CHOICE_CONTAINER_DATA_PERCEIVED_OBJECT_CONTAINER`  as the **Container Id** value
- Instantiates **Container Data** as `container_data_perceived_object_container`  and populates its attributes 